### PR TITLE
Fix bug w/ undo/redo when auto-adding rels

### DIFF
--- a/app_package/core_func.py
+++ b/app_package/core_func.py
@@ -157,15 +157,6 @@ def core_add_attr(pName, attr, attrType):
         db.session.add(new_attr)
         db.session.commit()
         
-        parsedType = parseType(attr)
-        if parsedType is not None:
-            # link it to the related class if applicable
-            ClassList = Class.query.all()
-            for CurrentClass in ClassList:
-                if CurrentClass.name == parsedType:
-                    core_add_rel(pName, CurrentClass.name, "agg")
-                    break
-        
         return 0
     except:
         db.session.rollback()

--- a/app_package/memento/func_objs.py
+++ b/app_package/memento/func_objs.py
@@ -1,7 +1,6 @@
-from ..core_func import (core_add, core_delete, core_add_attr, core_update, core_add_attr, core_del_attr, core_update_attr, core_add_rel, core_del_rel)
+from ..core_func import (core_add, core_delete, core_add_attr, core_update, core_add_attr, core_del_attr, core_update_attr, core_add_rel, core_del_rel, parseType)
 from ..models import Attribute, Class, Relationship
-from app_package import db
-
+from app_package import db, cmd_stack
 
 class Command:
     """The base class which all commands are a subclass
@@ -124,6 +123,15 @@ class add_attr(Command):
         self.attrType = attrType
 
     def execute(self):
+        parsedType = parseType(self.attrName)
+        if parsedType is not None:
+            # link it to the related class if applicable
+            ClassList = Class.query.all()
+            for CurrentClass in ClassList:
+                if CurrentClass.name == parsedType:
+                    cmd_stack.execute(add_rel(self.className, CurrentClass.name, "agg"))
+                    break
+        
         return core_add_attr(self.className, self.attrName, self.attrType)
 
     def undo(self):


### PR DESCRIPTION
# Primary and Secondary Authors
Nate and Deven

# Description

Move logic to auto-add relationships given existing type to Command execution. This allows undo/redo to see it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Existing tests cover this change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
